### PR TITLE
Travis: disable pycodestyle

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,9 @@
+pycodestyle:
+    max-line-length: 120  # Default is 79 in PEP8
+    ignore:  # Errors and warnings to ignore
+        - E501 # Line too long
+        - E122 # Continuation line missing indentation or outdented
+        - E126 # Continuation line over-indented for hanging indent
+        - E127 # Continuation line over-indented for visual indent
+        - E741 # Do not use variables named I, O or l
+        - W504 # Line break before / after binary operator

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,7 +1,6 @@
 pycodestyle:
     max-line-length: 120  # Default is 79 in PEP8
     ignore:  # Errors and warnings to ignore
-        - E501 # Line too long
         - E122 # Continuation line missing indentation or outdented
         - E126 # Continuation line over-indented for hanging indent
         - E127 # Continuation line over-indented for visual indent

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - make data/small
   - docker build . -t apertif/apercal
 script:
-  - docker run -v `pwd`/data:/code/data:rw apertif/apercal pycodestyle apercal --ignore=E501,E127,E741,E122,W504,E126
+#  - docker run -v `pwd`/data:/code/data:rw apertif/apercal pycodestyle apercal --ignore=E501,E127,E741,E122,W504,E126
   - docker run -v `pwd`/data:/code/data:rw apertif/apercal pytest -s test/test_prepare.py
   - docker run -v `pwd`/data:/code/data:rw apertif/apercal pytest -s test/test_preflag.py
   - docker run -v `pwd`/data:/code/data:rw apertif/apercal pytest -s test/test_ccal.py


### PR DESCRIPTION
Replace with pep8speaks. This separates failing builds / tests from code
style issues. Pep8speaks will make a github comment about codestyle.