### PR TITLE
Get .pep8speaks.yml working

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,8 +1,12 @@
+scanner:
+  diff_only: True  # Errors caused by only the patch are shown, not the whole file
+
 pycodestyle:
-    max-line-length: 120  # Default is 79 in PEP8
-    ignore:  # Errors and warnings to ignore
-        - E122 # Continuation line missing indentation or outdented
-        - E126 # Continuation line over-indented for hanging indent
-        - E127 # Continuation line over-indented for visual indent
-        - E741 # Do not use variables named I, O or l
-        - W504 # Line break before / after binary operator
+  max-line-length: 120
+  ignore:  # Errors and warnings to ignore
+    - W391 # blank line at the end of file
+    - E203 # whitespace before ,;:
+    - W503 # newline before binary operator
+
+no_blank_comment: True  # If True, no comment is made when the bot does not find any pep8 errors
+

--- a/test/test_preflag.py
+++ b/test/test_preflag.py
@@ -15,6 +15,8 @@ class TestPreflag(unittest.TestCase):
     def test_preflag(self):
         p = preflag()
         p.basedir = path.join(here, '../data/small/')
+        p.fluxcal = "This is just a very long line to see if pep8speaks still ignores .pep8speaks.yml"
+        p.fluxcal = "This is a ridiculously long line on which pep8speaks should trigger, because the line is longer than 120 characters"
         p.fluxcal = '3C295.MS'
         p.polcal = '3C138.MS'
         p.target = 'NGC807.MS'


### PR DESCRIPTION
Apparently .pep8speaks.yml isn't parsed. This file tells pep8speaks to ignore some code style issues (otherwise no pull request would ever make it). Debugging in this PR, please don't merge yet.