### PR TITLE
Phase-Selfcal fails if less than 3 minor cycles are performed

### DIFF
--- a/apercal/modules/scal.py
+++ b/apercal/modules/scal.py
@@ -619,6 +619,8 @@ class scal(BaseModule):
                                         else:
                                             TNreached = False
                                 else:
+                                    # set the minc counter back by one to when it reached the noise level before completing all minor cycles
+                                    minc -= 1
                                     pass
                             # Do the self calibration in the normal cycle
                             selfcaltargetbeamsphasefinalmajor = majc


### PR DESCRIPTION
When TNreached is set to True at the end of minc=1 (or minc=0), the next for loop will be started before TNreached is tested. Thus, the for-loop will exit with minc set to 2 (or minc=1). The subsequent selfcal step looks for a model in <majc>/model_02 (or <majc>/model_01) which do not exists, because the minor cycle stopped with model_01 (or model_00).