### PR TITLE
If fluxcal is None, pipeline should recognise that

### DIFF
--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -90,8 +90,11 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
     logger.debug("steps = {}".format(steps))
 
     status = pymp.shared.dict({beamnr: [] for beamnr in beamlist_target})
-
-    name_fluxcal = str(fluxcals[0][1]).strip().split('_')[0]
+    
+    if fluxcals:
+        name_fluxcal = str(fluxcals[0][1]).strip().split('_')[0]
+    else:
+        name_fluxcal = ''
     if polcals:
         name_polcal = str(polcals[0][1]).strip().split('_')[0]
     else:


### PR DESCRIPTION
To deal with this issue (polcals was already sorted):

  File "/home/moss/autocal/autocal.py", line 245, in <module>
    main()
  File "/home/moss/autocal/autocal.py", line 140, in main
    return_msg = start_apercal_pipeline(tdict['target'], tdict['cal1'], tdict['cal2'])
  File "/home/moss/apercal/apercal/pipeline/start_pipeline.py", line 94, in start_apercal_pipeline
    name_fluxcal = str(fluxcals[0][1]).strip().split('_')[0]
TypeError: 'NoneType' object has no attribute '__getitem__'