### PR TITLE
Fix convert rm uvfits

### DIFF
--- a/apercal/modules/convert.py
+++ b/apercal/modules/convert.py
@@ -412,10 +412,13 @@ class convert(BaseModule):
                 subs_managefiles.director(self, 'rm', mspath_to_fitspath(self.get_crosscalsubdir_path(), self.fluxcal))
             if self.polcal != '' and path.exists(mspath_to_fitspath(self.get_crosscalsubdir_path(), self.polcal)):
                 subs_managefiles.director(self, 'rm', mspath_to_fitspath(self.get_crosscalsubdir_path(), self.polcal))
-            for beam in range(self.NBEAMS):
-                basedir = self.get_crosscalsubdir_path(str(beam).zfill(2))
-                if path.isdir(basedir):
-                    subs_managefiles.director(self, 'rm', mspath_to_fitspath(basedir, self.target))
+            if self.target != '' and path.exists(mspath_to_fitspath(self.get_crosscalsubdir_path(), self.target)):
+                subs_managefiles.director(self, 'rm', mspath_to_fitspath(
+                    self.get_crosscalsubdir_path(), self.target))
+            # for beam in range(self.NBEAMS):
+            #     basedir = self.get_crosscalsubdir_path(str(beam).zfill(2))
+            #     if path.isdir(basedir):
+            #         subs_managefiles.director(self, 'rm', mspath_to_fitspath(basedir, self.target))
 
     def summary(self):
         """

--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -754,10 +754,16 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
             lib.setup_logger('debug', logfile=logfilepath)
             logger.info("Running line")
             start_time_line = time()
+
+            # Because of the amount of information coming from line
+            # this module gets its own logfile
+            logfilepath = os.path.join(basedir, 'apercal_line.log')
+            lib.setup_logger('debug', logfile=logfilepath)
         else:
             logfilepath = os.path.join(basedir, 'apercal.log')
             lib.setup_logger('debug', logfile=logfilepath)
             logger.info("Skipping line")
+
 
         for beamnr in beamlist_target:
             try:


### PR DESCRIPTION
Convert was removing UVFITS files from all beam directories for the target instead of just the beam directory it was working in. This fixed now.
Slightly off-topic: Line now has its own logfile.
Changes were tested