### PR TITLE
Avoid abort if polcal was not provided, still there if polcal fails

### DIFF
--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -837,7 +837,8 @@ class ccal(BaseModule):
                 subs_param.add_param(self, cbeam + '_fluxcal_transfer', ccalfluxcaltransfer)
                 subs_param.add_param(self, cbeam + '_polcal_transfer', ccalpolcaltransfer)
                 logger.error(error)
-                #raise RuntimeError(error)
+                # do not raise exception as it prevents the pipeline from running with fluxcal-only
+                # raise RuntimeError(error)
 
         subs_param.add_param(self, cbeam + '_fluxcal_transfer', ccalfluxcaltransfer)
         subs_param.add_param(self, cbeam + '_polcal_transfer', ccalpolcaltransfer)


### PR DESCRIPTION
Removed raising exception if there is no polarisation calibrator to which calibration solutions should be transferred to. Otherwise the pipeline would not work with fluxcal-only as it should.