### PR TITLE
Ref ant check

### DIFF
--- a/apercal/libs/lib.py
+++ b/apercal/libs/lib.py
@@ -767,3 +767,14 @@ def load_config(config_object, file_=None):
         for o in config.items(s):
             setattr(config_object, o[0], eval(o[1]))
     return config  # Save the loaded config file as defaults for later usage
+
+def get_default_config():
+    """
+    Function to get the default config settins
+    """
+
+    config = ConfigParser()
+
+    config.readfp(open(default_cfg))
+
+    return config

--- a/apercal/libs/lib.py
+++ b/apercal/libs/lib.py
@@ -768,6 +768,7 @@ def load_config(config_object, file_=None):
             setattr(config_object, o[0], eval(o[1]))
     return config  # Save the loaded config file as defaults for later usage
 
+
 def get_default_config():
     """
     Function to get the default config settins

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -174,11 +174,11 @@ class ccal(BaseModule):
                 
                 # change the setting in crosscal
                 # not strictly necessary here, but good to make the config file consistent
-                config.set("CROSSCAL", "crosscal_refant", crosscal_refant)
+                config.set("CROSSCAL", "crosscal_refant", "'{}'".format(crosscal_refant))
                 self.crosscal_refant = crosscal_refant
                 
                 # change the setting in selfcal
-                config.set("CROSSCAL", "selfcal_refant", refant_fluxcal_index)
+                config.set("Selfcal", "selfcal_refant", "'{}'".format(refant_fluxcal_index))
 
                 # make a copy of old config file
                 subs_managefiles.director(

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -6,6 +6,8 @@ import pandas as pd
 
 import casacore.tables as pt
 
+from ConfigParser import SafeConfigParser, ConfigParser
+
 from apercal.modules.base import BaseModule
 from apercal.subs import setinit as subs_setinit
 from apercal.subs import managefiles as subs_managefiles
@@ -41,10 +43,12 @@ class ccal(BaseModule):
     crosscal_transfer_to_target = None
     crosscal_refant = None
     crosscal_refant_exclude = ["RTC", "RTD"]
+    config_file_name = None
     
     def __init__(self, file_=None, **kwargs):
         self.default = lib.load_config(self, file_)
         subs_setinit.setinitdirs(self)
+        self.config_file_name = file_
 
     def go(self):
         """
@@ -110,8 +114,7 @@ class ccal(BaseModule):
         refant_in_fluxcal = crosscal_refant in fluxcal_ant_list
         
         if refant_in_fluxcal:
-            logger.info("Beam {0}: Reference antenna {1} exists in flux calibrator. Did not check polarisation calibration".format(self.beam, crosscal_refant))
-            # check also polcal list??
+            logger.info("Beam {0}: Reference antenna {1} exists in flux calibrator".format(self.beam, crosscal_refant))
         else:
             # since the reference antenna does not exists, choose the first available one in the list
             # this should not be RTC and RTD but just in case test it
@@ -132,7 +135,7 @@ class ccal(BaseModule):
 
         # if reference antenna is completely flagged, another one needs to be chosen
         if query_result[0]['all_flagged']:
-            logger.info("Beam {0}: All visibilities of reference antenna {1}. Choosing another one".format(self.beam, crosscal_refant))
+            logger.info("Beam {0}: All visibilities of reference antenna {1} are flagged. Choosing another one".format(self.beam, crosscal_refant))
             # go through the list of antennas
             ant_name = ""
             for ant_index in range(refant_fluxcal_index+1, len(fluxcal_ant_list)):
@@ -141,7 +144,7 @@ class ccal(BaseModule):
                     self.get_fluxcal_path(), ant_index)
                 query_ref_search_result = pt.taql(query_ref_search)
                 # if this one is not flagged
-                if not query_result[0]['all_flagged']:
+                if not query_ref_search_result[0]['all_flagged']:
                     # get the name
                     ant_name = fluxcal_ant_list[ant_index]
                     # check that it is not in the exclude list
@@ -149,6 +152,7 @@ class ccal(BaseModule):
                         logger.info(
                             "Beam {0}: Choosing {1} as the reference antenna".format(self.beam, ant_name))
                         crosscal_refant = ant_name
+                        refant_fluxcal_index = ant_index
                         break
             # not sure if this check is necessary
             if ant_name == "":
@@ -160,9 +164,43 @@ class ccal(BaseModule):
             logger.info("Reference antenna {0} is not completely flagged. Keeping it.")
 
         if crosscal_refant != self.crosscal_refant:
-            logger.info("Beam {0}: Chosen reference antenna {1} is different from config file setting. Adjusting settings for crosscal and selfcal".format(self.beam, crosscal_refant))
+            if self.config_file_name is not None:
+                logger.info("Beam {0}: Chosen reference antenna {1} is different from config file setting. Adjusting settings for crosscal and selfcal".format(self.beam, crosscal_refant))
+                # set config parser
+                config = ConfigParser()
+                # read the config file settings
+                with open(self.config_file_name, "r") as fp:
+                    config.readfp(fp)
+                
+                # change the setting in crosscal
+                # not strictly necessary here, but good to make the config file consistent
+                config.set("CROSSCAL", "crosscal_refant", crosscal_refant)
+                self.crosscal_refant = crosscal_refant
+                
+                # change the setting in selfcal
+                config.set("CROSSCAL", "selfcal_refant", refant_fluxcal_index)
+
+                # make a copy of old config file
+                subs_managefiles.director(
+                    self, 'rn', self.config_file_name.replace(".cfg", "_backup_wrong_refant.cfg"), file_=self.config_file_name, ignore_nonexistent=True)
+
+                # write changes to config file
+                with open(self.config_file_name, "w") as fp:
+                    config.write(fp)
+            else:
+                logger.info("Beam {0}: No config file was specified. Cannot adjust setting for selfcal. Changing reference antenna only for crosscal to {1}".format(self.beam, crosscal_refant))
+                self.crosscal_refant = crosscal_refant
         else:
             logger.info("Beam {0}: Reference antenna {1} set in config file is valid".format(self.beam, crosscal_refant))
+
+        # Checking polcal but not doing anything at the moment if it fails
+        refant_in_polcal = crosscal_refant in polcal_ant_list
+        if refant_in_polcal and self.polcal != '':
+            logger.info("Beam {0}: Reference antenna {1} exists in polarisation calibrator".format(
+                self.beam, crosscal_refant))
+        else:
+            logger.warning("Beam {0}: Reference antenna {1} does NOT exists in polarisation calibrator. Polarisation will probably fail.".format(
+                self.beam, crosscal_refant))
 
 
     def setflux(self):

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -40,8 +40,8 @@ class ccal(BaseModule):
     crosscal_transfer_to_cal = None
     crosscal_transfer_to_target = None
     crosscal_refant = None
-
-
+    crosscal_refant_exclude = ["RTC", "RTD"]
+    
     def __init__(self, file_=None, **kwargs):
         self.default = lib.load_config(self, file_)
         subs_setinit.setinitdirs(self)
@@ -61,6 +61,7 @@ class ccal(BaseModule):
         tranfer_to_target
         """
         logger.info("Starting CROSS CALIBRATION ")
+        self.check_ref_ant()
         self.setflux()
         self.initial_phase()
         self.global_delay()
@@ -72,6 +73,96 @@ class ccal(BaseModule):
         self.transfer_to_cal()
         self.transfer_to_target()
         logger.info("CROSS CALIBRATION done ")
+
+    def check_ref_ant(self):
+        """
+        Check that the default reference antenna.
+
+        This function tests whether the default reference antenna is 
+        available or not. If not, it uses the next antenna. It changes
+        the config file settings for crosscal and selfcal accordingly.
+        RTC and RTD have been excluded because of their performance. 
+        At the moment, the function only tests whether the entire reference
+        antenna is flagged.
+
+        Theses tests are based on the flux calibrator
+        """
+
+        # get the reference antenna
+        crosscal_refant = self.crosscal_refant
+        logger.info(
+            "Beam {0}: Checking reference antenna {1} set in config file".format(self.beam, crosscal_refant))
+
+        # get a list of antennas from the fluxcal MS file
+        query = "SELECT NAME FROM {}::ANTENNA".format(self.get_fluxcal_path())
+        query_result = pt.taql(query)
+        fluxcal_ant_list = np.array(query_result.getcol("NAME"))
+
+        if self.polcal != '':
+            # get a list of antennas from the polcal MS file
+            query = "SELECT NAME FROM {}::ANTENNA".format(self.get_polcal_path())
+            query_result = pt.taql(query)
+            polcal_ant_list = np.array(query_result.getcol("NAME"))
+        else:
+            polcal_ant_list = None
+
+        # check that the reference antenna is in the list of antennas
+        refant_in_fluxcal = crosscal_refant in fluxcal_ant_list
+        
+        if refant_in_fluxcal:
+            logger.info("Beam {0}: Reference antenna {1} exists in flux calibrator. Did not check polarisation calibration".format(self.beam, crosscal_refant))
+            # check also polcal list??
+        else:
+            # since the reference antenna does not exists, choose the first available one in the list
+            # this should not be RTC and RTD but just in case test it
+            for ant in fluxcal_ant_list:
+                if ant not in self.crosscal_refant_exclude:
+                    logger.info("Beam {0}: Could not find reference antenna {1} in flux calibrator. Chose {2} instead".format(self.beam, crosscal_refant, ant))
+                    crosscal_refant = ant
+                    refant_in_fluxcal = True
+                    break
+        
+        # get the index of the reference antenna
+        refant_fluxcal_index = np.where(fluxcal_ant_list == crosscal_refant)[0][0]
+        
+        # check if the entire referance antenna is flagged
+        # dropping "==0" would give the number of non-flagged data points
+        query = "SELECT GNFALSE(FLAG)==0 as all_flagged FROM {0} WHERE ANTENNA1=={1}".format(self.get_fluxcal_path(), refant_fluxcal_index)
+        query_result = pt.taql(query)
+
+        # if reference antenna is completely flagged, another one needs to be chosen
+        if query_result[0]['all_flagged']:
+            logger.info("Beam {0}: All visibilities of reference antenna {1}. Choosing another one".format(self.beam, crosscal_refant))
+            # go through the list of antennas
+            ant_name = ""
+            for ant_index in range(refant_fluxcal_index+1, len(fluxcal_ant_list)):
+                # check if it completely flagged
+                query_ref_search = "SELECT GNFALSE(FLAG)==0 as all_flagged FROM {0} WHERE ANTENNA1=={1}".format(
+                    self.get_fluxcal_path(), ant_index)
+                query_ref_search_result = pt.taql(query_ref_search)
+                # if this one is not flagged
+                if not query_result[0]['all_flagged']:
+                    # get the name
+                    ant_name = fluxcal_ant_list[ant_index]
+                    # check that it is not in the exclude list
+                    if ant_name not in self.crosscal_refant_exclude:
+                        logger.info(
+                            "Beam {0}: Choosing {1} as the reference antenna".format(self.beam, ant_name))
+                        crosscal_refant = ant_name
+                        break
+            # not sure if this check is necessary
+            if ant_name == "":
+                error = "Beam {0}: Could not find a new reference antenna. Abort crosscal".format(self.beam)
+                logger.error(error)
+                raise RuntimeError(error)
+        # reference antenna is not completely flagged
+        else:
+            logger.info("Reference antenna {0} is not completely flagged. Keeping it.")
+
+        if crosscal_refant != self.crosscal_refant:
+            logger.info("Beam {0}: Chosen reference antenna {1} is different from config file setting. Adjusting settings for crosscal and selfcal".format(self.beam, crosscal_refant))
+        else:
+            logger.info("Beam {0}: Reference antenna {1} set in config file is valid".format(self.beam, crosscal_refant))
 
 
     def setflux(self):

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -44,7 +44,7 @@ class ccal(BaseModule):
     crosscal_refant = None
     crosscal_refant_exclude = ["RTC", "RTD"]
     config_file_name = None
-    
+
     def __init__(self, file_=None, **kwargs):
         self.default = lib.load_config(self, file_)
         subs_setinit.setinitdirs(self)
@@ -112,7 +112,7 @@ class ccal(BaseModule):
 
         # check that the reference antenna is in the list of antennas
         refant_in_fluxcal = crosscal_refant in fluxcal_ant_list
-        
+
         if refant_in_fluxcal:
             logger.info("Beam {0}: Reference antenna {1} exists in flux calibrator".format(self.beam, crosscal_refant))
         else:
@@ -124,10 +124,10 @@ class ccal(BaseModule):
                     crosscal_refant = ant
                     refant_in_fluxcal = True
                     break
-        
+
         # get the index of the reference antenna
         refant_fluxcal_index = np.where(fluxcal_ant_list == crosscal_refant)[0][0]
-        
+
         # check if the entire referance antenna is flagged
         # dropping "==0" would give the number of non-flagged data points
         query = "SELECT GNFALSE(FLAG)==0 as all_flagged FROM {0} WHERE ANTENNA1=={1}".format(self.get_fluxcal_path(), refant_fluxcal_index)
@@ -138,7 +138,7 @@ class ccal(BaseModule):
             logger.info("Beam {0}: All visibilities of reference antenna {1} are flagged. Choosing another one".format(self.beam, crosscal_refant))
             # go through the list of antennas
             ant_name = ""
-            for ant_index in range(refant_fluxcal_index+1, len(fluxcal_ant_list)):
+            for ant_index in range(refant_fluxcal_index + 1, len(fluxcal_ant_list)):
                 # check if it completely flagged
                 query_ref_search = "SELECT GNFALSE(FLAG)==0 as all_flagged FROM {0} WHERE ANTENNA1=={1}".format(
                     self.get_fluxcal_path(), ant_index)
@@ -171,14 +171,14 @@ class ccal(BaseModule):
                 # read the config file settings
                 with open(self.config_file_name, "r") as fp:
                     config.readfp(fp)
-                
+
                 # change the setting in crosscal
                 # not strictly necessary here, but good to make the config file consistent
                 config.set("CROSSCAL", "crosscal_refant", "'{}'".format(crosscal_refant))
                 self.crosscal_refant = crosscal_refant
-                
+
                 # change the setting in selfcal
-                config.set("SELFCAL", "selfcal_refant", "'{}'".format(refant_fluxcal_index+1))
+                config.set("SELFCAL", "selfcal_refant", "'{}'".format(refant_fluxcal_index + 1))
 
                 # make a copy of old config file
                 logger.info("Beam {0}: Creating backup of config file before adjusting settings".format(self.beam))

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -161,7 +161,7 @@ class ccal(BaseModule):
                 raise RuntimeError(error)
         # reference antenna is not completely flagged
         else:
-            logger.info("Reference antenna {0} is not completely flagged. Keeping it.")
+            logger.info("Reference antenna {0} is not completely flagged. Keeping it.".format(crosscal_refant))
 
         if crosscal_refant != self.crosscal_refant:
             if self.config_file_name is not None:

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -181,10 +181,12 @@ class ccal(BaseModule):
                 config.set("Selfcal", "selfcal_refant", "'{}'".format(refant_fluxcal_index))
 
                 # make a copy of old config file
+                logger.info("Beam {0}: Creating backup of config file before adjusting settings".format(self.beam))
                 subs_managefiles.director(
                     self, 'rn', self.config_file_name.replace(".cfg", "_backup_wrong_refant.cfg"), file_=self.config_file_name, ignore_nonexistent=True)
 
                 # write changes to config file
+                logger.info("Beam {0}: Writing changes to config file {1}".format(self.beam, self.config_file_name))
                 with open(self.config_file_name, "w") as fp:
                     config.write(fp)
             else:

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -178,7 +178,7 @@ class ccal(BaseModule):
                 self.crosscal_refant = crosscal_refant
                 
                 # change the setting in selfcal
-                config.set("Selfcal", "selfcal_refant", "'{}'".format(refant_fluxcal_index+1))
+                config.set("SELFCAL", "selfcal_refant", "'{}'".format(refant_fluxcal_index+1))
 
                 # make a copy of old config file
                 logger.info("Beam {0}: Creating backup of config file before adjusting settings".format(self.beam))

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -178,7 +178,7 @@ class ccal(BaseModule):
                 self.crosscal_refant = crosscal_refant
                 
                 # change the setting in selfcal
-                config.set("Selfcal", "selfcal_refant", "'{}'".format(refant_fluxcal_index))
+                config.set("Selfcal", "selfcal_refant", "'{}'".format(refant_fluxcal_index+1))
 
                 # make a copy of old config file
                 logger.info("Beam {0}: Creating backup of config file before adjusting settings".format(self.beam))

--- a/apercal/modules/polarisation.py
+++ b/apercal/modules/polarisation.py
@@ -133,7 +133,8 @@ class polarisation(BaseModule):
                 pass
             else:
                 logger.warning(
-                    "Beam {}: Did not find polarisation calibrator miriad file in {} and convert-parameter is negative. Assuming that polarisation calibration failed. No polarisation imaging.".format(self.beam, convert_mir_file_polcal))
+                    "Beam {0}: Did not find polarisation calibrator miriad file in {1} and convert-parameter is negative.".format(self.beam, convert_mir_file_polcal)) 
+                logger.warning("Beam {}: Assuming that polarisation calibration failed. No polarisation imaging.".format(self.beam))
                 all_good = False
 
         # check selfcal

--- a/apercal/modules/polarisation.py
+++ b/apercal/modules/polarisation.py
@@ -95,12 +95,13 @@ class polarisation(BaseModule):
         """
 
         logger.info(
-            "Beam {}: Checking starting conditions for CONTINUUM IMAGING".format(self.beam))
+            "Beam {}: Checking starting conditions for POLARISATION IMAGING".format(self.beam))
 
         # initial setup
         subs_setinit.setinitdirs(self)
         subs_setinit.setdatasetnamestomiriad(self)
 
+        cbeam = 'convert_B' + str(self.beam).zfill(2)
         sbeam = 'selfcal_B' + str(self.beam).zfill(2)
         pbeam = 'polarisation_B' + str(self.beam).zfill(2)
 
@@ -109,9 +110,12 @@ class polarisation(BaseModule):
             self, sbeam + '_targetbeams_phase_status', False)
         selfcaltargetbeamsampstatus = get_param_def(
             self, sbeam + '_targetbeams_amp_status', False)
+        convertpolcaluvfits2miriad = get_param_def(
+            self, cbeam + '_polcal_UVFITS2MIRIAD', False)
 
         # path to miriad files
         convert_mir_file = os.path.join(self.crosscaldir, self.target)
+        convert_mir_file_polcal = os.path.join(self.crosscaldir, self.polcal)
 
         # variable to check that starting conditions are met
         all_good = True
@@ -122,6 +126,16 @@ class polarisation(BaseModule):
                 "Beam {}: Did not find main miriad file in {}".format(self.beam, convert_mir_file))
             all_good = False
         
+        if not os.path.isdir(convert_mir_file_polcal):
+            if convertpolcaluvfits2miriad:
+                # everything okay if either the miriad file or the parameter is set. Nothing to do here.
+                # the parameter is necessary for restarting without the polcal miriad file
+                pass
+            else:
+                logger.warning(
+                    "Beam {}: Did not find polarisation calibrator miriad file in {} and convert-parameter is negative. Assuming that polarisation calibration failed. No polarisation imaging.".format(self.beam, convert_mir_file_polcal))
+                all_good = False
+
         # check selfcal
         if not selfcaltargetbeamsphasestatus and not selfcaltargetbeamsampstatus:
             logger.warning("Beam {}: Neither phase nor amplitude self-calibration was successful. No polarisation imaging".format(self.beam))

--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -755,6 +755,7 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
                     p6.paramfilename = 'param_{:02d}.npy'.format(beamnr)
                     p6.basedir = basedir
                     p6.beam = "{:02d}".format(beamnr)
+                    p6.polcal = name_to_mir(name_polcal)
                     p6.target = name_to_mir(name_target)
                     if "polarisation" in steps and not dry_run:
                         p6.go()

--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -101,7 +101,7 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
         configfilename = os.path.join(basedir, "{}_Apercal_settings.cfg".format(taskid_target))
         # get the default config settings
         config = lib.get_default_config()
-        with open(configfilename,"w") as fp:
+        with open(configfilename, "w") as fp:
             config.write(fp)
         logger.info("Config file saved to {}".format(configfilename))
 

--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -74,6 +74,7 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
 
     (taskid_target, name_target, beamlist_target) = targets
 
+    # set the base directory if none was provided
     if not basedir:
         basedir = '/data/apertif/{}/'.format(taskid_target)
     elif len(basedir) > 0 and basedir[-1] != '/':
@@ -89,9 +90,20 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
                                       '&& git describe --tag; cd', shell=True).strip()
     logger.info("Apercal version: " + gitinfo)
 
-    logger.debug("start_apercal called with arguments targets={}; fluxcals={}; polcals={}".format(
+    logger.info("start_apercal called with arguments targets={}; fluxcals={}; polcals={}".format(
         targets, fluxcals, polcals))
-    logger.debug("steps = {}".format(steps))
+    logger.info("steps = {}".format(steps))
+
+    # get the default configfile if none was provided
+    if not configfilename:
+        logger.info("No config file provided, getting default config")
+        # set the config file name
+        configfilename = os.path.join(basedir, "{}_Apercal_settings.cfg".format(taskid_target))
+        # get the default config settings
+        config = lib.get_default_config()
+        with open(configfilename,"w") as fp:
+            config.write(fp)
+        logger.info("Config file saved to {}".format(configfilename))
 
     status = pymp.shared.dict({beamnr: [] for beamnr in beamlist_target})
 


### PR DESCRIPTION
Now, Apercal will check if the reference antenna is fully flagged in the flux calibrator or not. This was not done before. If it is flagged, it will select the next available antenna. It will also change the reference antenna set for selfcal in the configuration file. To this purpose, the pipeline itself creates a copy of the default config file in the base directory if no config file was specified. Checking the reference antenna is done entirely on the fluxcal at the moment. Perhaps it would be good to add this check for the polcal
Slightly unrelated, polarisation module now checks if there is a miriad file of the polcal in the crosscal directory or the corresponding convert parameter is True.