### PR TITLE
Flag on bandpass and fit autocorrelation

### DIFF
--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -947,9 +947,9 @@ class ccal(BaseModule):
                 bandpass_flag_list = []
                 for bad_ant in bad_ant_list:
                     if not bpass_check_results[bad_ant][0]:
-                        bandpass_flag_list.append([bad_ant, "XX"])
+                        bandpass_flag_list.append([bad_ant, 'XX'])
                     if not bpass_check_results[bad_ant][1]:
-                        bandpass_flag_list.append([bad_ant, "YY"])
+                        bandpass_flag_list.append([bad_ant, 'YY'])
                 self.crosscal_flag_list = bandpass_flag_list
                 self.crosscal_fluxcal_try_restart = True
             else:

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -919,7 +919,7 @@ class ccal(BaseModule):
                 else:
                     plot_path = "."
                 bp_plot_name = '{0}/BP_amp_Beam_{1}_ccal_{2}_{3}.png'.format(
-                    plot_path, self.beam, self.crosscal_try_counter, self.crosscal_fluxcal_try_counter))
+                    plot_path, self.beam, self.crosscal_try_counter, self.crosscal_fluxcal_try_counter)
                 
                 # this function returns a dictionary with true for good and false for bad solutions
                 bpass_check_results = ccal_utils.check_bpass_phase(fluxcal_bscan, self.crosscal_bandpass_phase_solution_max_std, plot_name=bp_plot_name, beam=str(self.beam).zfill(2))

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -355,14 +355,15 @@ class ccal(BaseModule):
                     self.reset(do_clearcal=False)
                     # do not change refant if there is a flag list
                     if self.crosscal_flag_list is not None:
+                        logger.debug("Beam {0}: Found the following new flags: {1}".format(
+                                self.beam, self.crosscal_flag_list))
                         # checking the number of antennas flagged in total
                         ccal_flag_list = subs_param.get_param_def(
                             self, cbeam + '_flag_list', [])
-                        if ccal_flag_list is not None:
-                            ccal_flag_list = ccal_flag_list + self.crosscal_flag_list
+                        ccal_flag_list = ccal_flag_list + self.crosscal_flag_list
                         # check that the list of flags is below the limit
                         if len(ccal_flag_list) != 0:
-                            logger.info("Beam {0}: Found the following flags: {1}".format(
+                            logger.debug("Beam {0}: This is the full list of flags for this beam: {1}".format(
                                 self.beam, ccal_flag_list))
                             # get a list flagged polarisation
                             pol_flag_list = np.array(
@@ -383,6 +384,7 @@ class ccal(BaseModule):
                             self.crosscal_flag_list = None
                     # change refant
                     else:
+                        logger.debug("Beam {0}: Changing reference antenna".format(self.beam))
                         self.check_ref_ant(check_flags=False, change_ref_ant=True)
                     # set the counter up
                     self.crosscal_fluxcal_try_counter += 1

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -194,9 +194,9 @@ class ccal(BaseModule):
                             logger.error(error)
                             raise RuntimeError(error)
                 else:
-                    logger.info("Beam {0}: Running cross-calibration attempt {1} (out of {2}) passed autocorrelation check. Continuing".format(
+                    logger.info("Beam {0}: Final cross-calibration attempt {1} (out of {2}) failed. ".format(
                     self.beam, self.crosscal_try_counter+1, self.crosscal_try_limit))
-                    crosscal_finished = True
+                    crosscal_finished = False
                     break
 
 

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -275,7 +275,7 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
-            else:
+            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
                 logger.error("Beam {0}: Final attempt {1} (out of {2}) failed at initial phase calibration.".format(
                     self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 break
@@ -296,7 +296,7 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
-            else:
+            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
                 logger.error(
                     "Beam {0}: Final attempt {1} (out of {2}) failed at global delay calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 break
@@ -322,7 +322,7 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
-            else:
+            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
                 logger.error(
                     "Beam {0}: Final attempt {1} (out of {2}) failed at bandpass calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 break
@@ -342,7 +342,7 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
-            else:
+            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
                 logger.error(
                     "Beam {0}: Final attempt {1} (out of {2}) failed at gain calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 break

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -50,6 +50,7 @@ class ccal(BaseModule):
     crosscal_refant_exclude = ["RTC", "RTD"]
     crosscal_ant_list = None
     crosscal_check_bandpass = None
+    crosscal_bandpass_phase_solution_max_std = None
     crosscal_check_autocorrelation = None
     crosscal_plot_autocorrelation = None
     crosscal_flag_limit = 4
@@ -103,6 +104,16 @@ class ccal(BaseModule):
             self.crosscal_autocorrelation_data_fraction_limit = 0.9
             logger.info("Limit of the fraction of data with autocorrelation amplitude above maximum value not specified. Setting to default: {}".format(
                 self.crosscal_autocorrelation_data_fraction_limit))
+        
+        if self.crosscal_check_bandpass is None:
+            self.crosscal_check_bandpass = True
+            logger.info("Check of bandpass solutions not provided. Setting to default: {}".format(
+                self.crosscal_check_bandpass))
+        
+        if self.crosscal_bandpass_phase_solution_max_std is None and self.crosscal_check_bandpass:
+            self.crosscal_bandpass_phase_solution_max_std = 10
+            logger.info("Maximum std of bandpass phase solutions not provided. Setting to default: {}".format(
+                self.crosscal_bandpass_phase_solution_max_std))
         
 
     def go(self):
@@ -830,7 +841,17 @@ class ccal(BaseModule):
         Function to check the quality of the bandpass phase solutions
         """
 
-        logger.info("Beam {}: Nothing to check yet".format(self.beam))
+        logger.info("Beam {}: Checking bandpass solutions".format(self.beam))
+
+        # path to bandpass table
+        fluxcal_bscan = self.get_fluxcal_path().rstrip('.MS') + '.Bscan'
+
+        # if there is a table check it
+        if os.path.isdir(fluxcal_bscan):
+            # this function returns a dictionary with true for good and false for bad solutions
+            bpass_check_results = ccal_utils.check_bpass_phase(self.bpath, self.crosscal_bandpass_phase_solution_max_std)
+
+            
 
     def gains(self):
         """

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -337,8 +337,12 @@ class ccal(BaseModule):
             if self.crosscal_fluxcal_try_restart: 
                 # unless it was the last attempt
                 if self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
-                    logger.warning(
-                        "Beam {0}: Attempt {1} (out of {2}) failed at bandpass calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    if self.crosscal_flag_list is not None:
+                        logger.warning(
+                            "Beam {0}: Attempt {1} (out of {2}) failed. Flagging bad antennas and restart ".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    else:
+                        logger.warning(
+                            "Beam {0}: Attempt {1} (out of {2}) failed at bandpass calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                     # reset first
                     self.reset(do_clearcal=False)
                     # do not change refant if there is a flag list
@@ -937,6 +941,7 @@ class ccal(BaseModule):
                     if not bpass_check_results[bad_ant][1]:
                         bandpass_flag_list.append([bad_ant, bpass_check_results[bad_ant][1]])
                 self.crosscal_flag_list = bandpass_flag_list
+                self.crosscal_fluxcal_try_restart = True
             else:
                 logger.info("Beam {0}: Found no antennas with bad solutions. All good.")
         

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -953,7 +953,7 @@ class ccal(BaseModule):
                 self.crosscal_flag_list = bandpass_flag_list
                 self.crosscal_fluxcal_try_restart = True
             else:
-                logger.info("Beam {0}: Found no antennas with bad solutions. All good.")
+                logger.info("Beam {}: Found no antennas with bad solutions. All good.".format(self.beam))
         
         logger.info("Beam {}: Checking bandpass solutions ... Done".format(self.beam))
 
@@ -1693,7 +1693,7 @@ class ccal(BaseModule):
                                     marker = 10, s = 1, label="{0}>{1}".format(pol_list[pol_nr], y_max), color='{}'.format(color_list_high[pol_nr]))
                 
             if self.crosscal_plot_autocorrelation:
-                plt.title('Antenna {0}'.format(ant))
+                plt.title('Antenna {0}'.format(ant_name))
                 plt.ylim(y_min, y_max)
 
             # run check of fit to autocorrelation
@@ -1702,8 +1702,8 @@ class ccal(BaseModule):
         # change the legend and save the file
         if self.crosscal_plot_autocorrelation:
             plt.legend(markerscale=3, fontsize=14)
-            plt.savefig(plt.savefig(
-                '{0}/Autocorrelation_Beam_{1}_ccal_{2}.png'.format(plot_path, self.beam, self.crosscal_try_counter)))
+            plt.savefig(
+                '{0}/Autocorrelation_Beam_{1}_ccal_{2}.png'.format(plot_path, self.beam, self.crosscal_try_counter))
 
         # cannot flag here only set restart
         # need to flag after resetting, otherwise flags are gone

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -32,6 +32,12 @@ gencal_cmd = 'gencal(vis="{vis}", caltable="{caltable}", caltype="{caltype}", in
 class ccal(BaseModule):
     """
     Crosscal class to handle applying the calibrator gains and prepare the dataset for self-calibration.
+
+    Crosscal contains several quality checks at two levels for the flux calibrator.
+    First, it checks whether CASA failed to create any of the flux calibrator calibration files and 
+    changes references antennas if one failed. Second, it checks the bandpass phase solutions. It will
+    restart with a different reference antenna in case too many telescope failed or just flag the telescopes.
+    Third, it checks the amplitude of the autocorrelation and flags a polarization if they are too high.
     """
 
     module_name = 'CROSSCAL'
@@ -178,6 +184,8 @@ class ccal(BaseModule):
             #self.apply_solutions()
             self.transfer_to_cal()
 
+            # Technically, this could happen before calibrating the polarisation calibrator
+            # but it is placed here in case checks of the polarised calibrator will be added
             if self.crosscal_check_autocorrelation:
                 self.check_autocorrelation()
             else:
@@ -1689,9 +1697,6 @@ class ccal(BaseModule):
             # run check of fit to autocorrelation
             logger.info("Checking fit of autocorrelation not yet available")
 
-            # run check of bandpass phase solutions
-            logger.info("Checking bandpass phase solution not yet available")
-        
         # change the legend and save the file
         if self.crosscal_plot_autocorrelation:
             plt.legend(markerscale=3, fontsize=14)

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -263,43 +263,45 @@ class ccal(BaseModule):
             # running initial phase calibration
             self.initial_phase()
             # if it fails, restart the loop after changing the reference antenna
-            # unless it is the last attempt
-            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
-                logger.warning("Beam {0}: Attempt {1} (out of {2}) failed at initial phase calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                # reset first
-                self.reset(do_clearcal=False)
-                # change refant
-                self.check_ref_ant(check_flags=False, change_ref_ant=True)
-                # set the counter up
-                self.crosscal_fluxcal_try_counter += 1
-                # set the status parameter
-                ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
-                continue
-            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
-                logger.error("Beam {0}: Final attempt {1} (out of {2}) failed at initial phase calibration.".format(
-                    self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                break
+            if self.crosscal_fluxcal_try_restart: 
+                # unless it is the last attempt
+                if self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
+                    logger.warning("Beam {0}: Attempt {1} (out of {2}) failed at initial phase calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    # reset first
+                    self.reset(do_clearcal=False)
+                    # change refant
+                    self.check_ref_ant(check_flags=False, change_ref_ant=True)
+                    # set the counter up
+                    self.crosscal_fluxcal_try_counter += 1
+                    # set the status parameter
+                    ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
+                    continue
+                else:
+                    logger.error("Beam {0}: Final attempt {1} (out of {2}) failed at initial phase calibration.".format(
+                        self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    break
 
             # running global delay calibration
             self.global_delay()
             # if it fails, restart the loop after changing the reference antenna
-            # unless it is the last attempt
-            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
-                logger.warning(
-                    "Beam {0}: Attempt {1} (out of {2}) failed at global delay calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                # reset first
-                self.reset(do_clearcal=False)
-                # change refant
-                self.check_ref_ant(check_flags=False, change_ref_ant=True)
-                # set the counter up
-                self.crosscal_fluxcal_try_counter += 1
-                # set the status parameter
-                ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
-                continue
-            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
-                logger.error(
-                    "Beam {0}: Final attempt {1} (out of {2}) failed at global delay calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                break
+            if self.crosscal_fluxcal_try_restart:
+                # unless it is the last attempt
+                if self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
+                    logger.warning(
+                        "Beam {0}: Attempt {1} (out of {2}) failed at global delay calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    # reset first
+                    self.reset(do_clearcal=False)
+                    # change refant
+                    self.check_ref_ant(check_flags=False, change_ref_ant=True)
+                    # set the counter up
+                    self.crosscal_fluxcal_try_counter += 1
+                    # set the status parameter
+                    ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
+                    continue
+                else:
+                    logger.error(
+                        "Beam {0}: Final attempt {1} (out of {2}) failed at global delay calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    break
 
             # running bandpass calibraiton
             self.bandpass()
@@ -309,43 +311,45 @@ class ccal(BaseModule):
             else:
                 logger.info("Beam {}: Did not check bandpass solutions".format(self.beam))
             # if it fails, restart the loop after changing the reference antenna
-            # unless it was the last attempt
-            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
-                logger.warning(
-                    "Beam {0}: Attempt {1} (out of {2}) failed at bandpass calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                # reset first
-                self.reset(do_clearcal=False)
-                # change refant
-                self.check_ref_ant(check_flags=False, change_ref_ant=True)
-                # set the counter up
-                self.crosscal_fluxcal_try_counter += 1
-                # set the status parameter
-                ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
-                continue
-            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
-                logger.error(
-                    "Beam {0}: Final attempt {1} (out of {2}) failed at bandpass calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                break
+            if self.crosscal_fluxcal_try_restart: 
+                # unless it was the last attempt
+                if self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
+                    logger.warning(
+                        "Beam {0}: Attempt {1} (out of {2}) failed at bandpass calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    # reset first
+                    self.reset(do_clearcal=False)
+                    # change refant
+                    self.check_ref_ant(check_flags=False, change_ref_ant=True)
+                    # set the counter up
+                    self.crosscal_fluxcal_try_counter += 1
+                    # set the status parameter
+                    ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
+                    continue
+                else:
+                    logger.error(
+                        "Beam {0}: Final attempt {1} (out of {2}) failed at bandpass calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    break
 
             self.gains()
             # if it fails, restart the loop after changing the reference antenna
-            # unless it was the last attempt
-            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
-                logger.warning(
-                    "Beam {0}: Attempt {1} (out of {2}) failed at gain calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                # reset first
-                self.reset(do_clearcal=False)
-                # change refant
-                self.check_ref_ant(check_flags=False, change_ref_ant=True)
-                # set the counter up
-                self.crosscal_fluxcal_try_counter += 1
-                # set the status parameter
-                ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
-                continue
-            elif self.crosscal_fluxcal_try_limit == self.crosscal_fluxcal_try_limit - 1:
-                logger.error(
-                    "Beam {0}: Final attempt {1} (out of {2}) failed at gain calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
-                break
+            if self.crosscal_fluxcal_try_restart: 
+                # unless it was the last attempt
+                if self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
+                    logger.warning(
+                        "Beam {0}: Attempt {1} (out of {2}) failed at gain calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    # reset first
+                    self.reset(do_clearcal=False)
+                    # change refant
+                    self.check_ref_ant(check_flags=False, change_ref_ant=True)
+                    # set the counter up
+                    self.crosscal_fluxcal_try_counter += 1
+                    # set the status parameter
+                    ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
+                    continue
+                else:
+                    logger.error(
+                        "Beam {0}: Final attempt {1} (out of {2}) failed at gain calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                    break
 
             # if this point is reached, crosscalibration should have worked
             crosscal_fluxcal_finished = True

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -653,7 +653,7 @@ class ccal(BaseModule):
                             logger.error(error)
                             
                             # leaving function in order to restart
-                            self.crosscal_try_restart = True
+                            self.crosscal_fluxcal_try_restart = True
                             return
                             #subs_param.add_param(self, cbeam + '_fluxcal_initialphase', ccalfluxcalinitialphase)
                             #raise RuntimeError(error)
@@ -722,7 +722,7 @@ class ccal(BaseModule):
                             logger.error('Beam ' + self.beam + ': Global delay correction table for flux calibrator was not created successfully!')
                             
                             # leaving function in order to restart
-                            self.crosscal_try_restart = True
+                            self.crosscal_fluxcal_try_restart = True
                             return
                 else:
                     ccalfluxcalglobaldelay = False
@@ -802,7 +802,7 @@ class ccal(BaseModule):
                             logger.error(error)
 
                             # leaving function in order to restart
-                            self.crosscal_try_restart = True
+                            self.crosscal_fluxcal_try_restart = True
                             return
                             #subs_param.add_param(self, cbeam + '_fluxcal_bandpass', ccalfluxcalbandpass)
                             #raise RuntimeError(error)
@@ -884,7 +884,7 @@ class ccal(BaseModule):
                             logger.error(error)
 
                             # leaving function in order to restart
-                            self.crosscal_try_restart = True
+                            self.crosscal_fluxcal_try_restart = True
                             return
                             
                             #subs_param.add_param(self, cbeam + '_fluxcal_apgains', ccalfluxcalapgains)

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -890,7 +890,7 @@ class ccal(BaseModule):
         # if there is a table check it
         if os.path.isdir(fluxcal_bscan):
             # this function returns a dictionary with true for good and false for bad solutions
-            bpass_check_results = ccal_utils.check_bpass_phase(self.bpath, self.crosscal_bandpass_phase_solution_max_std)
+            bpass_check_results = ccal_utils.check_bpass_phase(fluxcal_bscan, self.crosscal_bandpass_phase_solution_max_std)
 
             # now go through the list
             # get the number of antennas with bad solutions

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -935,21 +935,21 @@ class ccal(BaseModule):
             if n_ant_bad >= self.crosscal_flag_limit:
                 logger.warning("Beam {0}: Number of antennas with bad phase solutions exceeds defined limit: {1}. Going to restart flux calibrator calibration with different reference antenna".format(self.beam, self.crosscal_flag_limit))
                 self.crosscal_fluxcal_try_restart = True
-                return
+                # return
             elif rtc_bad and rtd_bad:
                 logger.warning("Beam {0}: RTC and RTD have bad phase solutions exceeding survey requirements. Going to restart flux calibrator calibration with different reference antenna".format(
                     self.beam, self.crosscal_flag_limit))
                 self.crosscal_fluxcal_try_restart = True
-                return
+                # return
             elif n_ant_bad != 0:
-                logger.warning("Beam {0}: Number of antennas with bad phase solutions below defined limit: {1}. Going to flag the affected polarisations and continue".format(self.beam, self.crosscal_flag_limit))
+                logger.warning("Beam {0}: Number of antennas with bad phase solutions below defined limit: {1}. Going to flag the affected antennas/polarisations and restart".format(self.beam, self.crosscal_flag_limit))
                 # get the list of flags
                 bandpass_flag_list = []
                 for bad_ant in bad_ant_list:
                     if not bpass_check_results[bad_ant][0]:
-                        bandpass_flag_list.append([bad_ant, bpass_check_results[bad_ant][0]])
+                        bandpass_flag_list.append([bad_ant, "XX"])
                     if not bpass_check_results[bad_ant][1]:
-                        bandpass_flag_list.append([bad_ant, bpass_check_results[bad_ant][1]])
+                        bandpass_flag_list.append([bad_ant, "YY"])
                 self.crosscal_flag_list = bandpass_flag_list
                 self.crosscal_fluxcal_try_restart = True
             else:

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -263,7 +263,8 @@ class ccal(BaseModule):
             # running initial phase calibration
             self.initial_phase()
             # if it fails, restart the loop after changing the reference antenna
-            if self.crosscal_fluxcal_try_restart:
+            # unless it is the last attempt
+            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
                 logger.warning("Beam {0}: Attempt {1} (out of {2}) failed at initial phase calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 # reset first
                 self.reset(do_clearcal=False)
@@ -274,11 +275,16 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
+            else:
+                logger.error("Beam {0}: Final attempt {1} (out of {2}) failed at initial phase calibration.".format(
+                    self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                break
 
             # running global delay calibration
             self.global_delay()
             # if it fails, restart the loop after changing the reference antenna
-            if self.crosscal_fluxcal_try_restart:
+            # unless it is the last attempt
+            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
                 logger.warning(
                     "Beam {0}: Attempt {1} (out of {2}) failed at global delay calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 # reset first
@@ -290,6 +296,10 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
+            else:
+                logger.error(
+                    "Beam {0}: Final attempt {1} (out of {2}) failed at global delay calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                break
 
             # running bandpass calibraiton
             self.bandpass()
@@ -299,7 +309,8 @@ class ccal(BaseModule):
             else:
                 logger.info("Beam {}: Did not check bandpass solutions".format(self.beam))
             # if it fails, restart the loop after changing the reference antenna
-            if self.crosscal_fluxcal_try_restart:
+            # unless it was the last attempt
+            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
                 logger.warning(
                     "Beam {0}: Attempt {1} (out of {2}) failed at bandpass calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 # reset first
@@ -311,10 +322,15 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
+            else:
+                logger.error(
+                    "Beam {0}: Final attempt {1} (out of {2}) failed at bandpass calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                break
 
             self.gains()
             # if it fails, restart the loop after changing the reference antenna
-            if self.crosscal_fluxcal_try_restart:
+            # unless it was the last attempt
+            if self.crosscal_fluxcal_try_restart and self.crosscal_fluxcal_try_counter < self.crosscal_fluxcal_try_limit - 1:
                 logger.warning(
                     "Beam {0}: Attempt {1} (out of {2}) failed at gain calibration. Trying to restart with different reference antenna".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
                 # reset first
@@ -326,6 +342,10 @@ class ccal(BaseModule):
                 # set the status parameter
                 ccal_fluxcal_calibration_restart = self.crosscal_fluxcal_try_restart
                 continue
+            else:
+                logger.error(
+                    "Beam {0}: Final attempt {1} (out of {2}) failed at gain calibration.".format(self.beam, self.crosscal_fluxcal_try_counter+1, self.crosscal_fluxcal_try_limit))
+                break
 
             # if this point is reached, crosscalibration should have worked
             crosscal_fluxcal_finished = True

--- a/apercal/modules/ccal.py
+++ b/apercal/modules/ccal.py
@@ -210,7 +210,7 @@ class ccal(BaseModule):
                         n_full_poll_flags_xx = len(np.where(pol_flag_list == "XX")[0])
                         n_full_poll_flags_yy = len(
                             np.where(pol_flag_list == "YY")[0])
-                        if n_full_poll_flags_xx > self.crosscal_flag_limit or n_full_poll_flags_yy > self.crosscal_flag_limit:
+                        if n_full_poll_flags_xx >= self.crosscal_flag_limit or n_full_poll_flags_yy >= self.crosscal_flag_limit:
                             error = "Beam {0}: Number of antennas with XX and YY flagged ({1}) exceeds defined limit {2}".format(self.beam, n_full_poll_flags, self.crosscal_flag_limit)
                             logger.error(error)
                             raise RuntimeError(error)
@@ -373,7 +373,7 @@ class ccal(BaseModule):
                                 np.where(pol_flag_list == "XX")[0])
                             n_full_poll_flags_yy = len(
                                 np.where(pol_flag_list == "YY")[0])
-                            if n_full_poll_flags_xx > self.crosscal_flag_limit or n_full_poll_flags_yy > self.crosscal_flag_limit:
+                            if n_full_poll_flags_xx >= self.crosscal_flag_limit or n_full_poll_flags_yy >= self.crosscal_flag_limit:
                                 error = "Beam {0}: Number of antennas with XX and YY flagged ({1}) exceeds defined limit {2}".format(
                                     self.beam, n_full_poll_flags, self.crosscal_flag_limit)
                                 logger.error(error)

--- a/apercal/modules/convert.py
+++ b/apercal/modules/convert.py
@@ -75,9 +75,9 @@ class convert(BaseModule):
 
         # Status of the solution transfer for the target, flux calibrator and polarisation calibrator
         ccal_targetbeams_transfer = get_param_def(
-            self, cbeam + '_targetbeams_transfer', False)
+            self, ccalbeam + '_targetbeams_transfer', False)
         ccal_calibration_calibrator_finished = get_param_def(
-            self, cbeam + '_calibration_calibrator_finished', False)
+            self, ccalbeam + '_calibration_calibrator_finished', False)
 
         if not ccal_calibration_calibrator_finished:
             error = "Beam {}: Will not convert files to miriad format because cross-calibration failed.".format(str(self.beam).zfill(2))

--- a/apercal/modules/convert.py
+++ b/apercal/modules/convert.py
@@ -67,7 +67,26 @@ class convert(BaseModule):
         """
         subs_setinit.setinitdirs(self)
 
+        ccalbeam = 'ccal_B' + str(self.beam).zfill(2)
         cbeam = 'convert_B' + str(self.beam).zfill(2)
+
+        # Read the parameters from crosscal
+        # and check before doing anything
+
+        # Status of the solution transfer for the target, flux calibrator and polarisation calibrator
+        ccal_targetbeams_transfer = get_param_def(
+            self, cbeam + '_targetbeams_transfer', False)
+        ccal_calibration_calibrator_finished = get_param_def(
+            self, cbeam + '_calibration_calibrator_finished', False)
+
+        if not ccal_calibration_calibrator_finished:
+            error = "Beam {}: Will not convert files to miriad format because cross-calibration failed.".format(str(self.beam).zfill(2))
+            logger.error(error)
+            raise RuntimeError(error)
+        elif not ccal_targetbeams_transfer:
+            error = "Beam {}: Will not convert files to miriad format because cross-calibration solutions were not successfully applied to target.".format(str(self.beam).zfill(2))
+            logger.error(error)
+            raise RuntimeError(error)
 
         # Create the parameters for the parameter file for converting from MS to UVFITS format
 

--- a/apercal/pipeline/start_pipeline.py
+++ b/apercal/pipeline/start_pipeline.py
@@ -659,10 +659,10 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
                         #     p2, 'rm', basedir + '/param_{:02d}.npy'.format(beamnr), ignore_nonexistent=True)
                         p2.go()
                         # it is necessary to move the param files in order to keep them
-                        param_file = os.path.join(
-                            basedir, 'param_{:02d}.npy'.format(beamnr))
-                        director(
-                            p2, 'rn', param_file.replace(".npy", "_crosscal.npy"), file_=param_file, ignore_nonexistent=True)
+                        # param_file = os.path.join(
+                        #     basedir, 'param_{:02d}.npy'.format(beamnr))
+                        # director(
+                        #     p2, 'rn', param_file.replace(".npy", "_crosscal.npy"), file_=param_file, ignore_nonexistent=True)
                 except Exception as e:
                     # Exception was already logged just before
                     logger.warning(
@@ -720,10 +720,10 @@ def start_apercal_pipeline(targets, fluxcals, polcals, dry_run=False, basedir=No
                         p3.go()
                         
                         # it is necessary to move the param files in order to keep them
-                        param_file = os.path.join(
-                            basedir, 'param_{:02d}.npy'.format(beamnr))
-                        director(
-                            p3, 'rn', param_file.replace(".npy", "_convert.npy"), file_=param_file, ignore_nonexistent=True)
+                        # param_file = os.path.join(
+                        #     basedir, 'param_{:02d}.npy'.format(beamnr))
+                        # director(
+                        #     p3, 'rn', param_file.replace(".npy", "_convert.npy"), file_=param_file, ignore_nonexistent=True)
                         # director(
                         #     p3, 'rm', basedir + '/param_{:02d}.npy'.format(beamnr), ignore_nonexistent=True)
                 except Exception as e:

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -229,7 +229,7 @@ def check_bpass_phase(bpath, max_std):
         freqs = t.getcol('CHAN_FREQ')
 
         # check for flags and mask
-        amp_sols[flags] = np.nan
+        # amp_sols[flags] = np.nan
         phase_sols[flags] = np.nan
 
         #time = times
@@ -258,6 +258,8 @@ def check_bpass_phase(bpath, max_std):
             cond = np.array([True, True])  # The reference antenna
         else:
             cond = std < max_std
+        logger.debug(
+            "=> Bandpass phase solutions are good? {}".format(str(cond)))
         res.update({ant: cond})
 
     return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -232,7 +232,6 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
         # check for flags and mask
         # amp_sols[flags] = np.nan
         phase_sols[flags] = np.nan
-        freqs[flags] = np.nan
 
         # time = times
         phase = phase_sols * 180./np.pi  # put into degrees
@@ -278,10 +277,10 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
         if plot_name is not None:
             plt.subplot(ny, nx, a_index+1)
             # plot XX
-            plt.scatter(freq_ant, phase_ant[0],
+            plt.scatter(freq_ant, phase_ant[:, 0],
                         label='XX',
                         marker=',', s=1, color='C0')
-            plt.scatter(freq_ant, phase_ant[1],
+            plt.scatter(freq_ant, phase_ant[:, 1],
                         label='YY',
                         marker=',', s=1, color='C1')
             plt.title('Antenna {0}'.format(ant))

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -285,10 +285,10 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
                         marker=',', s=1, color='C1')
             plt.title('Antenna {0}'.format(ant))
             plt.ylim(y_min, y_max)
-            plt.legend(markerscale=3, fontsize=14)
-            plt.savefig(plot_name)
 
     if plot_name is not None:
+        plt.legend(markerscale=3, fontsize=14)
+        plt.savefig(plot_name)
         plt.close('all')
 
     return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -254,5 +254,8 @@ def check_bpass_phase(bpath, max_std):
             pass
             # cond = np.array([True, True])  # The reference antenna
         else:
+            logger.debug("=> Will be flagged")
             cond = std >= max_std
         res.update({ant: cond})
+
+    return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -10,6 +10,7 @@ from scipy.optimize import curve_fit
 import logging
 from apercal.subs import misc as misc
 import os
+import matplotlib.pyplot as plt
 
 logger = logging.getLogger(__name__)
 

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -285,7 +285,7 @@ def check_bpass_phase(bpath, max_std, plot_name=None):
             plt.title('Antenna {0}'.format(ant_name))
             plt.ylim(y_min, y_max)
             plt.legend(markerscale=3, fontsize=14)
-            plt.savefig(plot_name))
+            plt.savefig(plot_name)
             plt.close('all')
 
     return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -194,7 +194,7 @@ def polyfit_autocorr(autocorrdata):
 #         res.update({ant: cond})
 #     return res
 
-def check_bpass_phase(bpath, max_std, plot_name=None):
+def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
     """
     Function to check the bandpass phase solutions to identify a bad antenna.
 
@@ -257,7 +257,7 @@ def check_bpass_phase(bpath, max_std, plot_name=None):
     ymax = 180
     plt.figure(figsize=(xsize, ysize))
     plt.suptitle(
-        'Bandpass phase solutions of Beam {}'.format(self.beam), size=30)
+        'Bandpass phase solutions of Beam {}'.format(beam), size=30)
 
     # go through the antennas
     for ant in ant_names:

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -5,7 +5,12 @@ Module with functionality to support cross-calibration
 # aperCC must be in the $PYTHONPATH
 # from aperCC.modules.Sols import BPSols
 import numpy as np
+import casacore.tables as pt
+from scipy.optimize import curve_fit
+import logging
+from apercal.subs import misc as misc
 
+logger = logging.getLogger(__name__)
 
 def get_ratio_autocorrelation_above_limit(amp, amp_threshold):
     """
@@ -26,6 +31,140 @@ def get_ratio_autocorrelation_above_limit(amp, amp_threshold):
     ratio_vis_above_threshold = float(n_vis_above_threshold) / float(n_vis)
 
     return ratio_vis_above_threshold
+
+
+def get_autocorr(msfile):
+    """
+    Gets the autocorrelation data from a dataset
+    msfile: Input dataset with the autocorrelations
+    """
+
+    # get the list of channels
+    # then get frequencies:
+    taql_antnames = "SELECT NAME FROM {0}::ANTENNA".format(msfile)
+    t = pt.taql(taql_antnames)
+    ant_names = t.getcol("NAME")
+    if ant_names is None:
+        logger.warning("Something wrong. No antenna names. Continue with next beam")
+
+    taql_freq = "SELECT CHAN_FREQ FROM {0}::SPECTRAL_WINDOW".format(msfile)
+    t = pt.taql(taql_freq)
+    freqs = t.getcol('CHAN_FREQ')[0, :]
+
+    # and number of stokes params
+    taql_stokes = "SELECT abs(DATA) AS amp from {0} limit 1".format(msfile)
+    t_pol = pt.taql(taql_stokes)
+    pol_array = t_pol.getcol('amp')
+    if pol_array is None:
+        logger.warning("Something wrong. No polarisation information. Continue with next beam")
+    n_stokes = pol_array.shape[2]  # shape is time, one, nstokes
+
+    # take MS file and get data
+    amp_ant_array = np.empty((len(ant_names), len(freqs), n_stokes), dtype=np.float32)
+
+    # get autocorrelation
+    for ant in xrange(len(ant_names)):
+        try:
+            taql_command = ("SELECT abs(gmeans(CORRECTED_DATA[FLAG])) AS amp "
+            "FROM {0} "
+            "WHERE ANTENNA1==ANTENNA2 && (ANTENNA1={1} || ANTENNA2={1})").format(msfile, ant)
+            t = pt.taql(taql_command)
+            amp_ant_array[ant, :, :] = t.getcol('amp')[0, :, :]  # phase_ant_array[ant, :, :] = t.getcol('phase')[0, :, :]
+        except Exception as e:
+            amp_ant_array[ant, :, :] = np.full((len(freqs), n_stokes), np.nan)
+            logger.exception(e)
+
+    # get XX and YY
+    amp_xx = amp_ant_array[:, :, 0]
+    amp_yy = amp_ant_array[:, :, 3]
+
+    return freqs, amp_xx, amp_yy
+
+
+def polyfit_autocorr(autocorrdata):
+    """
+    Function to remove outliers from the auto-correlations, fit a polynomial of 2nd order and issue flagging of dishes dependent on covariance of the fit and the parameters of determination
+    autocorrdata: Auto-correlation data in frequency, amp_xx, amp_yy order (usually from function get_autocorr)
+    returns: frequency values, cleaned auto-correlation values, polynomially fitted values, covariance of the fit, parameter of determination each for XX and YY
+    """
+    antnames = misc.create_antnames()
+    freqs = autocorrdata[0]
+    XX_rclean = []
+    XX_rfreq = []
+    XX_rpolyvals = []
+    XX_rcov = []
+    XX_rr2 = []
+    YY_rclean = []
+    YY_rfreq = []
+    YY_rpolyvals = []
+    YY_rcov = []
+    YY_rr2 = []
+    for dish in range(0,12):
+        XX_remove = np.where(autocorrdata[1][dish] == 0.0)
+        XX_clean = np.asarray(np.delete(autocorrdata[1][dish], XX_remove))
+        XX_freq = np.asarray(np.delete(freqs, XX_remove))
+        XX_mean = np.mean(XX_clean)
+        XX_sd = np.std(XX_clean)
+        XX_out = np.where((XX_clean < XX_mean - 3.0 * XX_sd) | (XX_clean > XX_mean + 3.0 * XX_sd))
+        XX_clean = np.delete(XX_clean, XX_out)
+        XX_freq = np.delete(XX_freq, XX_out)
+        try:
+            XX_poly, XX_covm = np.polyfit(XX_freq, XX_clean, 2, cov=True)
+            XX_polyvals = np.polyval(XX_poly, XX_freq)
+            XX_polyres = np.sum((XX_clean - XX_polyvals) ** 2.0)
+            XX_polytot = np.sum((XX_clean - np.mean(XX_clean)) ** 2.0)
+            XX_cov = np.sqrt(np.diag(XX_covm))
+            XX_r2 = 1.0 - (XX_polyres / XX_polytot)
+            XX_rclean.append(XX_clean)
+            XX_rfreq.append(XX_freq)
+            XX_rpolyvals.append(XX_polyvals)
+            XX_rcov.append(XX_cov)
+            XX_rr2.append(XX_r2)
+            if XX_r2 < 0.5 or XX_cov[0] >= 2e-16 or XX_cov[1] >= 1e-6 or XX_cov[2] >= 1e3:
+                print 'Dish ' + str(antnames[dish]) + ' XX flagged!'
+            else:
+                continue
+        except:
+            XX_rclean.append(np.asarray(np.nan))
+            XX_rfreq.append(np.asarray(np.nan))
+            XX_rpolyvals.append(np.asarray(np.nan))
+            XX_rcov.append(np.nan)
+            XX_rr2.append(np.nan)
+            print 'Dish ' + str(antnames[dish]) + ' XX flagged!'
+    for dish in range(0, 12):
+        YY_remove = np.where(autocorrdata[2][dish] == 0.0)
+        YY_clean = np.asarray(np.delete(autocorrdata[2][dish], YY_remove))
+        YY_freq = np.asarray(np.delete(freqs, YY_remove))
+        YY_mean = np.mean(YY_clean)
+        YY_sd = np.std(YY_clean)
+        YY_out = np.where((YY_clean < YY_mean - 3.0 * YY_sd) | (YY_clean > YY_mean + 3.0 * YY_sd))
+        YY_clean = np.delete(YY_clean, YY_out)
+        YY_freq = np.delete(YY_freq, YY_out)
+        try:
+            YY_poly, YY_covm = np.polyfit(YY_freq, YY_clean, 2, cov=True)
+            YY_polyvals = np.polyval(YY_poly, YY_freq)
+            YY_polyres = np.sum((YY_clean - YY_polyvals) ** 2.0)
+            YY_polytot = np.sum((YY_clean - np.mean(YY_clean)) ** 2.0)
+            YY_cov = np.sqrt(np.diag(YY_covm))
+            YY_r2 = 1.0 - (YY_polyres / YY_polytot)
+            YY_rclean.append(YY_clean)
+            YY_rfreq.append(YY_freq)
+            YY_rpolyvals.append(YY_polyvals)
+            YY_rcov.append(YY_cov)
+            YY_rr2.append(YY_r2)
+            if YY_r2 < 0.5 or YY_cov[0] >= 2e-16 or YY_cov[1] >= 1e-6 or YY_cov[2] >= 1e3:
+                print 'Dish ' + str(antnames[dish]) + ' YY flagged!'
+            else:
+                continue
+        except:
+            YY_rclean.append(np.asarray(np.nan))
+            YY_rfreq.append(np.asarray(np.nan))
+            YY_rpolyvals.append(np.asarray(np.nan))
+            YY_rcov.append(np.nan)
+            YY_rr2.append(np.nan)
+            print 'Dish ' + str(antnames[dish]) + ' YY flagged!'
+
+    return XX_rfreq, XX_rclean, XX_rpolyvals, XX_rcov, XX_rr2, YY_rfreq, YY_rclean, YY_rpolyvals, YY_rcov, YY_rr2
 
 
 # TODO: 1. Adjust the max_std (mb put to config); 2. Consider detrending...

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -287,6 +287,8 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
             plt.ylim(y_min, y_max)
             plt.legend(markerscale=3, fontsize=14)
             plt.savefig(plot_name)
-            plt.close('all')
+
+    if plot_name is not None:
+        plt.close('all')
 
     return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -239,9 +239,10 @@ def check_bpass_phase(bpath, max_std):
         freq = freqs / 1e9  # GHz
         #t0 = get_time(times[0])
     else:
-        error = "BP Table not found"
-        logger.error(error)
-        raise RuntimeError(error)
+        logger.warning(
+            "BP Table {} not found. Checking solutions not possible".format(bpath))
+        # logger.error(error)
+        # raise RuntimeError(error)
 
     # to store the results
     res = dict()

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -9,6 +9,7 @@ import casacore.tables as pt
 from scipy.optimize import curve_fit
 import logging
 from apercal.subs import misc as misc
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -253,8 +253,8 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
     ny = 3
     xsize = nx*4
     ysize = ny*4
-    ymin = -180
-    ymax = 180
+    y_min = -180
+    y_max = 180
     plt.figure(figsize=(xsize, ysize))
     plt.suptitle(
         'Bandpass phase solutions of Beam {}'.format(beam), size=30)

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -275,7 +275,7 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
         res.update({ant: cond})
 
         if plot_name is not None:
-            plt.subplot(ny, nx, ant+1)
+            plt.subplot(ny, nx, a_index+1)
             # plot XX
             plt.scatter(freq_ant, phase_ant[0],
                         label='XX',
@@ -283,7 +283,7 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
             plt.scatter(freq_ant, phase_ant[1],
                         label='YY',
                         marker=',', s=1, color='C1')
-            plt.title('Antenna {0}'.format(ant_name))
+            plt.title('Antenna {0}'.format(ant))
             plt.ylim(y_min, y_max)
             plt.legend(markerscale=3, fontsize=14)
             plt.savefig(plot_name)

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -232,6 +232,7 @@ def check_bpass_phase(bpath, max_std, plot_name=None, beam=''):
         # check for flags and mask
         # amp_sols[flags] = np.nan
         phase_sols[flags] = np.nan
+        freqs[flags] = np.nan
 
         # time = times
         phase = phase_sols * 180./np.pi  # put into degrees

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -197,14 +197,16 @@ def check_bpass_phase(bpath, max_std):
     Function to check the bandpass phase solutions to identify a bad antenna.
 
     It checks if the standard deviation of the bandpass phase solutions is below
-    a maximum standard deviation. If it is above, the antenna should get flagged.
+    a maximum standard deviation. The return is a dictionary with entries for each
+    antenna and booleans for each polarisation. If the standard deviation is below
+    the limit, it is True (i.e., good). If it is below, it is False (i.e., bad).    
 
     Args:
         bpath (str): Path to bandpass file
         max_std (float): Maximum standard deviation of phase solutions
 
     Return
-        results (dict):
+        results (dict({ant: [XX_phase<max_std, YY_phase<max_std]})): Check for each antenna and polarisaiton
     """
 
     # get the data from the bandpass table
@@ -251,11 +253,9 @@ def check_bpass_phase(bpath, max_std):
         std = np.nanstd(phase_ant, axis=0)
         logger.debug("Ant: {0}, std = {1}".format(ant, std))
         if not np.isfinite(std[0]) and not np.isfinite(std[1]):
-            pass
-            # cond = np.array([True, True])  # The reference antenna
+            cond = np.array([True, True])  # The reference antenna
         else:
-            logger.debug("=> Will be flagged")
-            cond = std >= max_std
+            cond = std < max_std
         res.update({ant: cond})
 
     return res

--- a/apercal/subs/ccal_utils.py
+++ b/apercal/subs/ccal_utils.py
@@ -193,14 +193,14 @@ def polyfit_autocorr(autocorrdata):
 #         res.update({ant: cond})
 #     return res
 
-def check_bpass_phase(bpath, max_std):
-    """ 
+def check_bpass_phase(bpath, max_std, plot_name=None):
+    """
     Function to check the bandpass phase solutions to identify a bad antenna.
 
     It checks if the standard deviation of the bandpass phase solutions is below
     a maximum standard deviation. The return is a dictionary with entries for each
     antenna and booleans for each polarisation. If the standard deviation is below
-    the limit, it is True (i.e., good). If it is below, it is False (i.e., bad).    
+    the limit, it is True (i.e., good). If it is below, it is False (i.e., bad).
 
     Args:
         bpath (str): Path to bandpass file
@@ -232,12 +232,12 @@ def check_bpass_phase(bpath, max_std):
         # amp_sols[flags] = np.nan
         phase_sols[flags] = np.nan
 
-        #time = times
+        # time = times
         phase = phase_sols * 180./np.pi  # put into degrees
-        #amp = amp_sols
-        #flags = flags
+        # amp = amp_sols
+        # flags = flags
         freq = freqs / 1e9  # GHz
-        #t0 = get_time(times[0])
+        # t0 = get_time(times[0])
     else:
         logger.warning(
             "BP Table {} not found. Checking solutions not possible".format(bpath))
@@ -246,6 +246,17 @@ def check_bpass_phase(bpath, max_std):
 
     # to store the results
     res = dict()
+
+    # setting plot layout
+    nx = 4
+    ny = 3
+    xsize = nx*4
+    ysize = ny*4
+    ymin = -180
+    ymax = 180
+    plt.figure(figsize=(xsize, ysize))
+    plt.suptitle(
+        'Bandpass phase solutions of Beam {}'.format(self.beam), size=30)
 
     # go through the antennas
     for ant in ant_names:
@@ -261,5 +272,20 @@ def check_bpass_phase(bpath, max_std):
         logger.debug(
             "=> Bandpass phase solutions are good? {}".format(str(cond)))
         res.update({ant: cond})
+
+        if plot_name is not None:
+            plt.subplot(ny, nx, ant+1)
+            # plot XX
+            plt.scatter(freq_ant, phase_ant[0],
+                        label='XX',
+                        marker=',', s=1, color='C0')
+            plt.scatter(freq_ant, phase_ant[1],
+                        label='YY',
+                        marker=',', s=1, color='C1')
+            plt.title('Antenna {0}'.format(ant_name))
+            plt.ylim(y_min, y_max)
+            plt.legend(markerscale=3, fontsize=14)
+            plt.savefig(plot_name))
+            plt.close('all')
 
     return res


### PR DESCRIPTION
This update to crosscal includes a new check of the bandpass phase solutions to improve the calibration. In addition, there is a function to fit the autocorrelation for flagging in ccal_utils, but it is not yet incorporated into the crosscal module and not fully tested.
This branch also fixes a bug in crosscal which prevented switching reference antennas and a bug in convert which allowed it to convert data that was not calibrated. The latter case also required an update to the pipeline so that there are no separate npy files from crosscal and convert.